### PR TITLE
Fix 2566 cloud config date converts to object

### DIFF
--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -21,6 +21,7 @@ import TableView from 'dashboard/TableView.react';
 import Toolbar from 'components/Toolbar/Toolbar.react';
 import browserStyles from 'dashboard/Data/Browser/Browser.scss';
 import { CurrentApp } from 'context/currentApp';
+import { formatParsedDate } from '../../../lib/DateUtils';
 
 @subscribeTo('Config', 'config')
 class Config extends TableView {
@@ -112,7 +113,7 @@ class Config extends TableView {
     if (type === 'object') {
       if (isDate(value)) {
         type = 'Date';
-        value = value.toISOString();
+        value = formatParsedDate(value);
       } else if (Array.isArray(value)) {
         type = 'Array';
         value = JSON.stringify(value);

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -245,7 +245,7 @@ class Config extends TableView {
     return data;
   }
 
-  saveParam({ name, value, type,  masterKeyOnly }) {
+  saveParam({ name, value, type, masterKeyOnly }) {
     this.props.config
       .dispatch(ActionTypes.SET, {
         param: name,
@@ -258,28 +258,39 @@ class Config extends TableView {
           const limit = this.context.cloudConfigHistoryLimit;
           const applicationId = this.context.applicationId;
           let transformedValue = value;
-          if(type === 'Date') {
-            transformedValue = {__type: 'Date', iso: value};
+          if (type === 'Date') {
+            transformedValue = { __type: 'Date', iso: value };
           }
-          if(type === 'File') {
-            transformedValue = {name: value._name, url: value._url};
+          if (type === 'File') {
+            transformedValue = { name: value._name, url: value._url };
           }
           const configHistory = localStorage.getItem(`${applicationId}_configHistory`);
-          if(!configHistory) {
-            localStorage.setItem(`${applicationId}_configHistory`, JSON.stringify({
-              [name]: [{
-                time: new Date(),
-                value: transformedValue
-              }]
-            }));
+          if (!configHistory) {
+            localStorage.setItem(
+              `${applicationId}_configHistory`,
+              JSON.stringify({
+                [name]: [
+                  {
+                    time: new Date(),
+                    value: transformedValue,
+                  },
+                ],
+              })
+            );
           } else {
             const oldConfigHistory = JSON.parse(configHistory);
-            localStorage.setItem(`${applicationId}_configHistory`, JSON.stringify({
-              ...oldConfigHistory,
-              [name]: !oldConfigHistory[name] ?
-                [{time: new Date(), value: transformedValue}]
-                : [{time: new Date(), value: transformedValue}, ...oldConfigHistory[name]].slice(0, limit || 100)
-            }));
+            localStorage.setItem(
+              `${applicationId}_configHistory`,
+              JSON.stringify({
+                ...oldConfigHistory,
+                [name]: !oldConfigHistory[name]
+                  ? [{ time: new Date(), value: transformedValue }]
+                  : [
+                      { time: new Date(), value: transformedValue },
+                      ...oldConfigHistory[name],
+                    ].slice(0, limit || 100),
+              })
+            );
           }
         },
         () => {
@@ -292,10 +303,11 @@ class Config extends TableView {
     this.props.config.dispatch(ActionTypes.DELETE, { param: name }).then(() => {
       this.setState({ showDeleteParameterDialog: false });
     });
-    const configHistory = localStorage.getItem('configHistory') && JSON.parse(localStorage.getItem('configHistory'));
-    if(configHistory) {
+    const configHistory =
+      localStorage.getItem('configHistory') && JSON.parse(localStorage.getItem('configHistory'));
+    if (configHistory) {
       delete configHistory[name];
-      if(Object.keys(configHistory).length === 0) {
+      if (Object.keys(configHistory).length === 0) {
         localStorage.removeItem('configHistory');
       } else {
         localStorage.setItem('configHistory', JSON.stringify(configHistory));

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -114,6 +114,7 @@ class Config extends TableView {
       if (isDate(value)) {
         type = 'Date';
         value = formatParsedDate(value);
+        modalValue = value;
       } else if (Array.isArray(value)) {
         type = 'Array';
         value = JSON.stringify(value);

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -199,23 +199,27 @@ export default class ConfigDialog extends React.Component {
         ))}
       </Dropdown>
     );
-    const configHistory = localStorage.getItem(`${this.context.applicationId}_configHistory`) && JSON.parse(localStorage.getItem(`${this.context.applicationId}_configHistory`))[this.state.name];
+    const configHistory =
+      localStorage.getItem(`${this.context.applicationId}_configHistory`) &&
+      JSON.parse(localStorage.getItem(`${this.context.applicationId}_configHistory`))[
+        this.state.name
+      ];
     const handleIndexChange = index => {
-      if(this.state.type === 'Date'){
+      if (this.state.type === 'Date') {
         return;
       }
       let value = configHistory[index].value;
-      if(this.state.type === 'File'){
+      if (this.state.type === 'File') {
         const fileJSON = {
           __type: 'File',
           name: value.name,
-          url: value.url
+          url: value.url,
         };
         const file = Parse.File.fromJSON(fileJSON);
         this.setState({ selectedIndex: index, value: file });
         return;
       }
-      if(typeof value === 'object'){
+      if (typeof value === 'object') {
         value = JSON.stringify(value);
       }
       this.setState({ selectedIndex: index, value });
@@ -265,27 +269,26 @@ export default class ConfigDialog extends React.Component {
           */
           semver.valid(this.props.parseServerVersion) &&
           semver.gte(this.props.parseServerVersion, '3.9.0') ? (
-              <Field
-                label={
-                  <Label
-                    text="Requires master key?"
-                    description="When set to yes the parameter is returned only when requested with the master key. You can change it at any time."
-                  />
-                }
-                input={
-                  <Toggle
-                    type={Toggle.Types.YES_NO}
-                    value={this.state.masterKeyOnly}
-                    onChange={masterKeyOnly => this.setState({ masterKeyOnly })}
-                    additionalStyles={{ margin: '0px' }}
-                  />
-                }
-                className={styles.addColumnToggleWrapper}
-              />
-            ) : null
+            <Field
+              label={
+                <Label
+                  text="Requires master key?"
+                  description="When set to yes the parameter is returned only when requested with the master key. You can change it at any time."
+                />
+              }
+              input={
+                <Toggle
+                  type={Toggle.Types.YES_NO}
+                  value={this.state.masterKeyOnly}
+                  onChange={masterKeyOnly => this.setState({ masterKeyOnly })}
+                  additionalStyles={{ margin: '0px' }}
+                />
+              }
+              className={styles.addColumnToggleWrapper}
+            />
+          ) : null
         }
-        {
-          configHistory?.length > 0 &&
+        {configHistory?.length > 0 && (
           <Field
             label={
               <Label
@@ -294,19 +297,17 @@ export default class ConfigDialog extends React.Component {
               />
             }
             input={
-              <Dropdown
-                value={this.state.selectedIndex}
-                onChange={handleIndexChange}>
-                {configHistory.map((value, i) =>
+              <Dropdown value={this.state.selectedIndex} onChange={handleIndexChange}>
+                {configHistory.map((value, i) => (
                   <Option key={i} value={i}>
                     {dateStringUTC(new Date(value.time))}
                   </Option>
-                )}
+                ))}
               </Dropdown>
             }
             className={styles.addColumnToggleWrapper}
           />
-        }
+        )}
       </Modal>
     );
   }

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -48,7 +48,10 @@ const EDITORS = {
   Number: (value, onChange) => (
     <TextInput value={value || ''} onChange={numberValidator(onChange)} />
   ),
-  Date: (value, onChange) => <DateTimeInput fixed={true} value={value} onChange={onChange} />,
+  Date: (value, onChange) => {
+    const date = value === null ? null : new Date(value);
+    return <DateTimeInput fixed={true} value={date} onChange={onChange} />;
+  },
   Object: (value, onChange) => (
     <TextInput
       multiline={true}

--- a/src/lib/DateUtils.js
+++ b/src/lib/DateUtils.js
@@ -32,8 +32,11 @@ export const WEEKDAYS = [
 
 const toString = Object.prototype.toString;
 
+const isParsedDate = obj => obj && obj.__type === 'Date' && typeof obj.iso === 'string';
+const isDateObj = obj => typeof obj === 'object' && toString.call(obj).indexOf('Date') > -1;
+
 export function isDate(obj) {
-  return typeof obj === 'object' && toString.call(obj).indexOf('Date') > -1;
+  return isDateObj(obj) || isParsedDate(obj);
 }
 
 export function getWeekday(n) {
@@ -170,4 +173,16 @@ export function pad(number) {
     r = '0' + r;
   }
   return r;
+}
+
+/*  Prevent the date from being a object as
+ *  { __type: 'Date', iso: '2019-01-01T00:00:00.000Z' } for example.
+ */
+export function formatParsedDate(date) {
+  if (isParsedDate(date)) {
+    const parsedDate = new Date(date.iso);
+    return parsedDate.toISOString();
+  } else if (isDateObj(date)) {
+    return date.toISOString();
+  }
 }

--- a/src/lib/tests/DateUtils.test.js
+++ b/src/lib/tests/DateUtils.test.js
@@ -14,6 +14,19 @@ describe('isDate', () => {
     expect(DateUtils.isDate(12)).toBe(false);
     expect(DateUtils.isDate({})).toBe(false);
   });
+
+  it('returns true for Parse date objects', () => {
+    const parseDate = { __type: 'Date', iso: '2024-09-03T05:42:00.000Z' };
+    expect(DateUtils.isDate(parseDate)).toBe(true);
+  })
+
+  it('returns false for objects that look like dates but are not valid', () => {
+    const invalidDate = { __type: 'Date', iso: 123 };
+    expect(DateUtils.isDate(invalidDate)).toBe(false);
+
+    const incompleteParseDate = { __type: 'Date' };
+    expect(DateUtils.isDate(incompleteParseDate)).toBe(false);
+  });
 });
 
 describe('shortMonth', () => {
@@ -63,5 +76,19 @@ describe('daysInMonth', () => {
     expect(DateUtils.daysInMonth(new Date(2015, 1))).toBe(28);
     expect(DateUtils.daysInMonth(new Date(2012, 1))).toBe(29);
     expect(DateUtils.daysInMonth(new Date(2015, 8))).toBe(30);
+  });
+});
+
+describe('formatParsedDate', () => {
+  it('correctly formats a native Date object to ISO string', () => {
+    const date = new Date('2024-09-03T05:42:00.000Z');
+    const formattedDate = DateUtils.formatParsedDate(date);
+    expect(formattedDate).toBe(date.toISOString());
+  });
+
+  it('correctly formats a Parse Date object to ISO string', () => {
+    const parseDate = { __type: 'Date', iso: '2024-09-03T05:42:00.000Z' };
+    const formattedDate = DateUtils.formatParsedDate(parseDate);
+    expect(formattedDate).toBe('2024-09-03T05:42:00.000Z');
   });
 });


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
When creating a Date config param and refreshing the page, the ISO Date string was transforming in a parsed date object (see example in the [issue](https://github.com/parse-community/parse-dashboard/issues/2566). Then, the user was unable to edit the param field, since it was identified as an object. [More details](https://github.com/parse-community/parse-dashboard/issues/2566).

Closes: FILL_THIS_OUT

### Approach
I found out that when refreshing the page, the date string was being transformed:

`if (type === 'Date') { transformedValue = { __type: 'Date', iso: value };} `

So I created a method that translate the parsed date obj to an date iso string: `formatParsedDate()`. Convert the ISO string to Date() at `ConfigDialog.react.js` to go through `<DateTimeInput/>`  component when opening the edit modal. And finally, implemented new test routines to the method created and other scenarios to `isDate()` method, since it was modified to also ensure parsed date objects are dates after all.

Additionally I adjusted the code to the project prettier rules.

### TODOs before merging

- [x] Manual test
- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
